### PR TITLE
6 set up dotenv for reading environment variables

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint/eslint-plugin", "prettier"],
+  "plugins": ["import", "@typescript-eslint/eslint-plugin", "prettier"],
   "overrides": [
     {
       "files": ["*.ts"],
@@ -21,12 +21,18 @@
   ],
   "settings": {
     "import/resolver": {
-      "typescript": {}
+      "typescript": {
+        "alwaysTryTypes": true
+      }
+    },
+    "import/parsers": {
+      "@typescript-eslint/parser": [".ts"]
     }
   },
   "rules": {
     "quotes": "off",
     "no-throw-literal": "off",
+    "import/no-unresolved": "error",
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
     "import/extensions": [
       "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.20.1",
+        "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "express-validator": "^6.14.3"
       },
@@ -2627,6 +2628,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dynamic-dedupe": {
@@ -9548,6 +9557,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "dynamic-dedupe": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "body-parser": "^1.20.1",
+    "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "express-validator": "^6.14.3"
   }

--- a/src/loaders/express.ts
+++ b/src/loaders/express.ts
@@ -1,5 +1,6 @@
 import { Application } from "express";
 import bodyParser, { urlencoded } from "body-parser";
+import appConfig from "@utils/appConfig";
 
 const loadExpress = async ({ app }: { app: Application }) => {
   app.use(bodyParser.json());
@@ -9,7 +10,7 @@ const loadExpress = async ({ app }: { app: Application }) => {
   app.use((req, res, next) => {
     res.setHeader(
       "Access-Control-Allow-Origin",
-      process.env.CORS_ORIGIN as string,
+      appConfig.express.corsOrigin as string,
     );
     res.setHeader("Access-Control-Allow-Credentials", "true");
     res.setHeader(

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import appConfig from "@utils/appConfig";
 import app from "./app";
 import runLoaders from "./loaders";
 
@@ -5,9 +6,8 @@ import runLoaders from "./loaders";
   await runLoaders(app);
 })();
 
-const PORT = 5000;
-const server = app.listen(PORT, () => {
-  console.log(`Listening on port ${PORT}...`);
+const server = app.listen(appConfig.express.serverPort, () => {
+  console.log(`Listening on port ${appConfig.express.serverPort}...`);
 });
 
 const gracefulShutdown = (cause: string) => {

--- a/src/utils/appConfig.ts
+++ b/src/utils/appConfig.ts
@@ -1,0 +1,29 @@
+import dotenv from "dotenv";
+
+export interface IAppConfig {
+  express: {
+    serverPort: string | undefined;
+    corsOrigin: string | undefined;
+  };
+}
+
+/* Load environment variables. If we're not running in a production environment, then
+ * get the variables from a .env file. Otherwise, use the deployed environment. */
+if (
+  process.env.NODE_ENV !== "production" &&
+  process.env.NODE_ENV !== "testci"
+) {
+  const configOutput = dotenv.config({ path: `.env.${process.env.NODE_ENV}` });
+  if (configOutput.error) {
+    throw new Error("Error loading environment variables");
+  }
+}
+
+const appConfig: IAppConfig = {
+  express: {
+    serverPort: process.env.SERVER_PORT,
+    corsOrigin: process.env.CORS_ORIGIN,
+  },
+};
+
+export default appConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,8 +30,10 @@
     "module": "commonjs" /* Specify what module code is generated. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    "baseUrl": "./src" /* Specify the base directory to resolve non-relative module names. */,
+    "paths": {
+      "@utils/*": ["utils/*"]
+    } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     "typeRoots": [
       "./src/types",


### PR DESCRIPTION
This set of commits introduces the `dotenv` package to the project for reading environment variables. Those variables are read and stored in an `appConfig` object that can be passed around to different components.

This way, we have one global "source of truth" regarding app configuration that is easy to update when necessary.

Closes #6.